### PR TITLE
Adding back process.on(['SIGTERM', 'SIGINT'] to allow service to exit

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -4,6 +4,11 @@ const server = require('./server/server')
 const messaging = require('./messaging')
 const legacyProcessing = require('./legacy-processing')
 
+process.on(['SIGTERM', 'SIGINT'], async () => {
+  await messaging.stop()
+  process.exit(0)
+})
+
 const startApp = async () => {
   await server.start()
   if (processingConfig.processingActive) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-pay-tracking",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-pay-tracking",
-      "version": "1.3.18",
+      "version": "1.3.19",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-tracking",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "description": "Track payments and publish notifications",
   "homepage": "https://github.com/DEFRA/ffc-pay-tracking",
   "main": "app/index.js",


### PR DESCRIPTION
During the last release of this service the below code was removed.

`process.on(['SIGTERM', 'SIGINT'], async () => {
  await messaging.stop()
  process.exit(0)
})`

This PR has been made to add this code back in, as it is an integral part of the service.